### PR TITLE
Update Greece country code from "EL" to "GR"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 exports.getEuMembers = function()
 {
-	return ["BE", "BG", "CZ", "DK", "DE", "EE", "IE", "EL", "ES", "FR", "HR", "IT", "CY", "LV", "LT", "LU", "HU", "MT", "NL", "AT", "PL", "PT", "RO", "SI", "SK", "FI", "SE"];
+	return ["BE", "BG", "CZ", "DK", "DE", "EE", "IE", "GR", "ES", "FR", "HR", "IT", "CY", "LV", "LT", "LU", "HU", "MT", "NL", "AT", "PL", "PT", "RO", "SI", "SK", "FI", "SE"];
 };
 exports.isEuMember = function(code)
 {


### PR DESCRIPTION
Greece country code used for shipping purposes is GR.
Please refer: https://countrycode.org/greece and http://www.fedex.com/bq/tracking/codes.html